### PR TITLE
Fix `null_pointset.out` in validator output files

### DIFF
--- a/validator/src/main/java/com/google/daq/mqtt/validator/Validator.java
+++ b/validator/src/main/java/com/google/daq/mqtt/validator/Validator.java
@@ -509,7 +509,12 @@ public class Validator {
       event.timestamp = new Date();
       String subFolder = origAttributes.get("subFolder");
       event.sub_folder = subFolder;
-      event.sub_type = origAttributes.get("subType");
+      if (Strings.isNullOrEmpty(origAttributes.get("subType"))) {
+        event.sub_type = UNKNOWN_TYPE_DEFAULT;
+      } else {
+        origAttributes.get("subType");
+      }
+
       List<Entry> errors = reportingDevice.getErrors(validationStart);
       event.status = ReportingDevice.getSummaryEntry(errors);
       event.errors = errors != null && errors.size() > 1 ? errors : null;


### PR DESCRIPTION
Just an example to share what fixes the issue https://github.com/faucetsdn/udmi/issues/404 

Draft because just example and not the right fix which I reckon is an `attributes.sub_type` object which returns `event` directly