### PR TITLE
🧹 Fix race condition in `IotReflectorClient` transaction

### DIFF
--- a/validator/src/main/java/com/google/bos/iot/core/proxy/IotReflectorClient.java
+++ b/validator/src/main/java/com/google/bos/iot/core/proxy/IotReflectorClient.java
@@ -617,6 +617,13 @@ public class IotReflectorClient implements MessagePublisher {
 
   @Override
   public String publish(String deviceId, String topic, String data) {
+    return publish(deviceId, topic, data, getNextTransactionId());
+  }
+
+  /**
+   * Publish a message with a specific transaction id.
+   */
+  public String publish(String deviceId, String topic, String data, String transactionId) {
     updateLastProgressEvent();
     Envelope envelope = new Envelope();
     envelope.deviceRegistryId = registryId;
@@ -625,7 +632,6 @@ public class IotReflectorClient implements MessagePublisher {
     envelope.subFolder = SubFolder.fromValue(parts[0]);
     envelope.subType = SubType.fromValue(parts[1]);
     envelope.payload = GeneralUtils.encodeBase64(data);
-    String transactionId = getNextTransactionId();
     envelope.transactionId = transactionId;
     envelope.publishTime = new Date();
     publishStats.update();

--- a/validator/src/main/java/com/google/bos/iot/core/proxy/IotReflectorClient.java
+++ b/validator/src/main/java/com/google/bos/iot/core/proxy/IotReflectorClient.java
@@ -617,13 +617,11 @@ public class IotReflectorClient implements MessagePublisher {
 
   @Override
   public String publish(String deviceId, String topic, String data) {
-    return publish(deviceId, topic, data, getNextTransactionId());
+    return publish(deviceId, topic, data, (java.util.function.Consumer<String>) null);
   }
 
-  /**
-   * Publish a message with a specific transaction id.
-   */
-  public String publish(String deviceId, String topic, String data, String transactionId) {
+  @Override
+  public String publish(String deviceId, String topic, String data, java.util.function.Consumer<String> prePublishHook) {
     updateLastProgressEvent();
     Envelope envelope = new Envelope();
     envelope.deviceRegistryId = registryId;
@@ -632,9 +630,13 @@ public class IotReflectorClient implements MessagePublisher {
     envelope.subFolder = SubFolder.fromValue(parts[0]);
     envelope.subType = SubType.fromValue(parts[1]);
     envelope.payload = GeneralUtils.encodeBase64(data);
+    String transactionId = getNextTransactionId();
     envelope.transactionId = transactionId;
     envelope.publishTime = new Date();
     publishStats.update();
+    if (prePublishHook != null) {
+      prePublishHook.accept(transactionId);
+    }
     publisher.publish(registryId, getPublishTopic(), stringify(envelope));
     return transactionId;
   }

--- a/validator/src/main/java/com/google/daq/mqtt/util/IotReflectorClient.java
+++ b/validator/src/main/java/com/google/daq/mqtt/util/IotReflectorClient.java
@@ -213,9 +213,11 @@ public class IotReflectorClient implements IotProvider {
 
   private Map<String, Object> transaction(String deviceId, String topic,
       String message, QuerySpeed speed) {
-    // TODO: Publish should return future to avoid race conditions.
-    String transactionId = messageClient.publish(deviceId, topic, message);
-    Map<String, Object> objectMap = waitForReply(transactionId, speed);
+    String transactionId = com.google.bos.iot.core.proxy.IotReflectorClient.getNextTransactionId();
+    CompletableFuture<Map<String, Object>> replyFuture = new CompletableFuture<>();
+    futures.put(transactionId, replyFuture);
+    messageClient.publish(deviceId, topic, message, transactionId);
+    Map<String, Object> objectMap = waitForReply(transactionId, speed, replyFuture);
     String error = (String) ofNullable(objectMap).map(x -> x.get(ERROR_KEY)).orElse(null);
     if (error != null) {
       writeErrorDetail(transactionId, error, (String) objectMap.get(DETAIL_KEY));
@@ -242,10 +244,9 @@ public class IotReflectorClient implements IotProvider {
     }
   }
 
-  private Map<String, Object> waitForReply(String sentId, QuerySpeed speed) {
+  private Map<String, Object> waitForReply(String sentId, QuerySpeed speed,
+      CompletableFuture<Map<String, Object>> replyFuture) {
     try {
-      CompletableFuture<Map<String, Object>> replyFuture = new CompletableFuture<>();
-      futures.put(sentId, replyFuture);
       return speed == QuerySpeed.DYNAMIC ? dynamicReplyFutureGet(replyFuture) :
           replyFuture.get(speed.seconds(), TimeUnit.SECONDS);
     } catch (Exception e) {

--- a/validator/src/main/java/com/google/daq/mqtt/util/IotReflectorClient.java
+++ b/validator/src/main/java/com/google/daq/mqtt/util/IotReflectorClient.java
@@ -213,10 +213,9 @@ public class IotReflectorClient implements IotProvider {
 
   private Map<String, Object> transaction(String deviceId, String topic,
       String message, QuerySpeed speed) {
-    String transactionId = com.google.bos.iot.core.proxy.IotReflectorClient.getNextTransactionId();
     CompletableFuture<Map<String, Object>> replyFuture = new CompletableFuture<>();
-    futures.put(transactionId, replyFuture);
-    messageClient.publish(deviceId, topic, message, transactionId);
+    String transactionId = messageClient.publish(deviceId, topic, message,
+        publishedId -> futures.put(publishedId, replyFuture));
     Map<String, Object> objectMap = waitForReply(transactionId, speed, replyFuture);
     String error = (String) ofNullable(objectMap).map(x -> x.get(ERROR_KEY)).orElse(null);
     if (error != null) {

--- a/validator/src/main/java/com/google/daq/mqtt/util/MessagePublisher.java
+++ b/validator/src/main/java/com/google/daq/mqtt/util/MessagePublisher.java
@@ -47,6 +47,12 @@ public interface MessagePublisher {
 
   String publish(String deviceId, String topic, String data);
 
+  default String publish(String deviceId, String topic, String data, java.util.function.Consumer<String> prePublishHook) {
+    String publishedId = publish(deviceId, topic, data);
+    prePublishHook.accept(publishedId);
+    return publishedId;
+  }
+
   default String publish(String deviceId, String topic, String data, PublishPriority priority) {
     return publish(deviceId, topic, data);
   }


### PR DESCRIPTION
🎯 **What:** Modified `IotReflectorClient` to generate the transaction ID and wait on a Future *before* actually publishing the message to avoid a potential race condition where the reply arrives and is dropped before the waiting map is updated.
💡 **Why:** To improve robustness when responses are very quick, eliminating the window of opportunity where a reply is not handled properly.
✅ **Verification:** Verified with `gradlew build` that the project compiles correctly. Tests passed normally except for independent missing files in the environment.
✨ **Result:** Improved asynchronous reliability in `IotReflectorClient`.

---
*PR created automatically by Jules for task [15253859005543893128](https://jules.google.com/task/15253859005543893128) started by @grafnu*