### PR TITLE
docs: Add URL-like connection string documentation to UUFI spec

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -225,3 +225,8 @@ writeable
 Writeback
 writeback
 yaml
+UUFI
+subfolder
+setpoints
+Mosquitto
+mTLS

--- a/docs/specs/uufi.md
+++ b/docs/specs/uufi.md
@@ -31,6 +31,7 @@ You can use optional tags like `user@` and `:port` as necessary within the URL f
 *   The `user@` prefix maps to a `+user` suffix on the subscription.
 *   The `:port` suffix is invalid and should not be used.
 *   The first URL path part, if present, maps to a `path~` prefix on the topic and subscription.
+*   *Example:* `pubsub://my-user@my-project/my-prefix` maps to the GCP project `my-project`, with the `udmi_uufi` topic prefixed as `my-prefix~udmi_uufi`, and the receive subscription named `my-prefix~udmi_uufi+my-user`.
 
 **MQTT (`mqtt://`)**
 *   The base `host` and `:port` map as expected.

--- a/docs/specs/uufi.md
+++ b/docs/specs/uufi.md
@@ -35,7 +35,8 @@ You can use optional tags like `user@` and `:port` as necessary within the URL f
 
 **MQTT (`mqtt://`)**
 *   The base `host` and `:port` map as expected.
-*   The `user@` prefix maps to a `username` property that's added to the MQTT topic path.
+*   The `user@` prefix maps to a `username` property that's added to the MQTT topic path (e.g., as the `{source}` identifier in `/uufi/c/{source}/...`).
+*   *Example:* `mqtt://my-user@localhost:8883` maps to the MQTT broker at `localhost:8883` and adds `my-user` into the MQTT topic path (e.g., `/uufi/c/my-user/...`).
 
 ### 2.2. PubSub Transport
 The Client must have access to the GCP project where the UDMI system is deployed.

--- a/docs/specs/uufi.md
+++ b/docs/specs/uufi.md
@@ -19,7 +19,16 @@ UUFI utilizes a messaging transport where the Client interacts with the System v
 
 ## 2. Connectivity and Authentication
 
-### 2.1. PubSub Transport
+### 2.1. Connection String Designator
+To provide a standard way to connect into the system using a single string designator, UUFI interfaces support a URL-like connection string format. The two supported schemes are `mqtt://` and `pubsub://`.
+
+You can use optional tags like `user@` and `:port` as necessary within the URL format.
+
+Examples:
+*   **PubSub:** `pubsub://project-id`
+*   **MQTT:** `mqtt://localhost:1883`, `mqtt://user@localhost:8883`
+
+### 2.2. PubSub Transport
 The Client must have access to the GCP project where the UDMI system is deployed.
 
 *   **Project ID:** The GCP project ID.
@@ -27,7 +36,7 @@ The Client must have access to the GCP project where the UDMI system is deployed
 *   **Receive Subscription:** A subscription to the `udmi_uufi` topic (e.g., `prefix-udmi_uufi-user_id`).
 *   **Authentication:** Standard **GCP IAM**.
 
-### 2.2. MQTT Transport (Local Mosquitto)
+### 2.3. MQTT Transport (Local Mosquitto)
 For local testing or on-premise deployments, a standard MQTT broker (like Mosquitto) can be used.
 
 *   **Broker URL:** Typically `tcp://localhost:1883` or `ssl://localhost:8883`.

--- a/docs/specs/uufi.md
+++ b/docs/specs/uufi.md
@@ -24,9 +24,17 @@ To provide a standard way to connect into the system using a single string desig
 
 You can use optional tags like `user@` and `:port` as necessary within the URL format.
 
-Examples:
-*   **PubSub:** `pubsub://project-id`
-*   **MQTT:** `mqtt://localhost:1883`, `mqtt://user@localhost:8883`
+#### Protocol Mapping
+
+**PubSub (`pubsub://`)**
+*   The base `host` maps to the GCP project.
+*   The `user@` prefix maps to a `+user` suffix on the subscription.
+*   The `:port` suffix is invalid and should not be used.
+*   The first URL path part, if present, maps to a `path~` prefix on the topic and subscription.
+
+**MQTT (`mqtt://`)**
+*   The base `host` and `:port` map as expected.
+*   The `user@` prefix maps to a `username` property that's added to the MQTT topic path.
 
 ### 2.2. PubSub Transport
 The Client must have access to the GCP project where the UDMI system is deployed.


### PR DESCRIPTION
Added documentation for the standard single string URL-like format for connecting to UUFI, including support for `pubsub://` and `mqtt://` schemes along with optional tags like user and port. Shifted existing sections down.

---
*PR created automatically by Jules for task [13473214727325428889](https://jules.google.com/task/13473214727325428889) started by @grafnu*