### PR TITLE
feat(validator): strict validation for modbus interpretation parameters

### DIFF
--- a/validator/src/main/java/com/google/daq/mqtt/util/providers/ModbusFamilyProvider.java
+++ b/validator/src/main/java/com/google/daq/mqtt/util/providers/ModbusFamilyProvider.java
@@ -37,6 +37,11 @@ public class ModbusFamilyProvider implements FamilyProvider {
   private static final Set<String> ALLOWED_PARAMS =
       ImmutableSet.of("border", "type", "worder", "scale", "offset");
 
+  private static final Set<String> ALLOWED_BORDERS = ImmutableSet.of("MSB", "LSB");
+  private static final Set<String> ALLOWED_WORDERS = ImmutableSet.of("HWF", "LWF");
+  private static final Set<String> ALLOWED_TYPES =
+      ImmutableSet.of("INT16", "INT32", "INT64", "UINT16", "UINT32", "UINT64", "FLOAT32", "FLOAT64", "BOOLEAN", "ASCII");
+
   @Override
   public String familyKey() {
     return MODBUS;
@@ -66,9 +71,39 @@ public class ModbusFamilyProvider implements FamilyProvider {
     String query = matcher.group(5);
     if (query != null) {
       Arrays.stream(query.split("&")).forEach(param -> {
-        String key = param.split("=")[0];
+        String[] parts = param.split("=");
+        String key = parts[0];
         if (!ALLOWED_PARAMS.contains(key)) {
           throw new RuntimeException(format("invalid modbus interpretation parameter %s", key));
+        }
+        if (parts.length < 2) {
+          throw new RuntimeException(format("missing value for modbus interpretation parameter %s", key));
+        }
+        String value = parts[1];
+        switch (key) {
+          case "border":
+            if (!ALLOWED_BORDERS.contains(value)) {
+              throw new RuntimeException(format("invalid modbus border value %s", value));
+            }
+            break;
+          case "worder":
+            if (!ALLOWED_WORDERS.contains(value)) {
+              throw new RuntimeException(format("invalid modbus worder value %s", value));
+            }
+            break;
+          case "type":
+            if (!ALLOWED_TYPES.contains(value)) {
+              throw new RuntimeException(format("invalid modbus type value %s", value));
+            }
+            break;
+          case "scale":
+          case "offset":
+            try {
+              Double.parseDouble(value);
+            } catch (NumberFormatException e) {
+              throw new RuntimeException(format("invalid modbus %s value %s", key, value));
+            }
+            break;
         }
       });
     }

--- a/validator/src/test/java/com/google/daq/mqtt/util/providers/ModbusFamilyProviderTest.java
+++ b/validator/src/test/java/com/google/daq/mqtt/util/providers/ModbusFamilyProviderTest.java
@@ -32,7 +32,7 @@ public class ModbusFamilyProviderTest {
       "modbus://10.0.0.1/1/3/40001/1?type=UINT32&worder=HWF&border=LSB&scale=10&offset=5"
   );
 
-  public static final Set<String> BAD_REFERENCES = ImmutableSet.of(
+    public static final Set<String> BAD_REFERENCES = ImmutableSet.of(
       "modbus://network@192.168.1.1:502/1/3/40001",
       "modbus://192.168.1.1:502/1/3",
       "modbus://192.168.1.1:502/1/3/40001/10/extra",
@@ -42,6 +42,12 @@ public class ModbusFamilyProviderTest {
       "modbus://192.168.1.1:502/1/7/40001", // Invalid function code 7
       "modbus://192.168.1.1:502/1/3/40001?foo=bar", // Invalid parameter foo
       "modbus://192.168.1.1:502/1/3/40001?byte_order=MSB", // Old parameter name
+      "modbus://10.0.0.1/1/3/40001/1?type=BADTYPE",
+      "modbus://10.0.0.1/1/3/40001/1?border=BADBORDER",
+      "modbus://10.0.0.1/1/3/40001/1?worder=BADWORDER",
+      "modbus://10.0.0.1/1/3/40001/1?scale=abc",
+      "modbus://10.0.0.1/1/3/40001/1?offset=xyz",
+      "modbus://10.0.0.1/1/3/40001/1?type", // Missing value
       "bacnet://192.168.1.1/1/3/40001"
   );
 


### PR DESCRIPTION
- Updated `ModbusFamilyProvider` to strictly validate `type`, `border`, `worder` using explicit standard sets.
- Updated `ModbusFamilyProvider` to attempt parsing for `scale` and `offset` as Doubles.
- Updated `ModbusFamilyProviderTest` to ensure exceptions are thrown correctly.

---
*PR created automatically by Jules for task [14990286169878127190](https://jules.google.com/task/14990286169878127190) started by @grafnu*