### PR TITLE
Update DBO pointset semantic mapping to output is the value

### DIFF
--- a/bin/dbo_extract.py
+++ b/bin/dbo_extract.py
@@ -120,17 +120,22 @@ def extract_dbo_config(site_model_dir: Path) -> dict:
           # if it was stripped (though usually it's one-to-one).
           # For now, ensure the UDMI unit is represented.
           udmi_unit = point_info["units"]
-          if udmi_unit not in u["values"]:
+          if udmi_unit not in u["values"].values():
             u["values"][udmi_unit] = udmi_unit
+        if "values" in u:
+          u["values"] = {v: k for k, v in u["values"].items()}
         pt_dbo["units"] = u
 
       if "states" not in pt_dbo and "value_map" in point_info:
-        pt_dbo["states"] = point_info["value_map"]
+        pt_dbo["states"] = {v: k for k, v in point_info["value_map"].items()}
       elif "states" in pt_dbo and "value_map" in point_info:
         # Merge back any states that were stripped as identities
         for k, v in point_info["value_map"].items():
-          if k not in pt_dbo["states"]:
-            pt_dbo["states"][k] = v
+          if k not in pt_dbo["states"].values():
+            pt_dbo["states"][v] = k
+        pt_dbo["states"] = {v: k for k, v in pt_dbo["states"].items()}
+      elif "states" in pt_dbo:
+        pt_dbo["states"] = {v: k for k, v in pt_dbo["states"].items()}
 
       if len(pt_dbo) > 1 or pt_dbo.get("present_value") != f"points.{point_name}.present_value":
         translations[point_name] = pt_dbo

--- a/bin/dbo_merge.py
+++ b/bin/dbo_merge.py
@@ -159,7 +159,7 @@ def merge_dbo_config(yaml_file: Path, site_model_dir: Path):
             udmi_unit = list(pt_dbo["units"]["values"].keys())[0]
             pt_udmi["units"] = udmi_unit
           if "states" in pt_dbo:
-            pt_udmi["value_map"] = pt_dbo["states"]
+            pt_udmi["value_map"] = {v: k for k, v in pt_dbo["states"].items()}
           
           # Clean up pt_dbo before storing to avoid redundancy
           clean_pt_dbo = pt_dbo.copy()
@@ -172,7 +172,7 @@ def merge_dbo_config(yaml_file: Path, site_model_dir: Path):
               del u["key"]
             if "values" in u:
               # Only keep non-identity mappings
-              u["values"] = {k: v for k, v in u["values"].items() if k != v}
+              u["values"] = {v: k for k, v in u["values"].items() if k != v}
               if not u["values"]:
                 del u["values"]
             if not u:

--- a/tests/dbo/basic/site_model_expected/devices/VAV-1/metadata.json
+++ b/tests/dbo/basic/site_model_expected/devices/VAV-1/metadata.json
@@ -19,7 +19,7 @@
         "translation": {
           "units": {
             "values": {
-              "degrees_celsius": "degC"
+              "degC": "degrees_celsius"
             }
           }
         }

--- a/tests/dbo/basic/site_model_expected/devices/VAV-2/metadata.json
+++ b/tests/dbo/basic/site_model_expected/devices/VAV-2/metadata.json
@@ -26,7 +26,7 @@
         "translation": {
           "units": {
             "values": {
-              "degrees_celsius": "degC"
+              "degC": "degrees_celsius"
             }
           }
         }

--- a/tests/dbo/basic/site_model_expected/devices/VAV-3/metadata.json
+++ b/tests/dbo/basic/site_model_expected/devices/VAV-3/metadata.json
@@ -19,7 +19,7 @@
         "translation": {
           "units": {
             "values": {
-              "liters_per_second": "L/s"
+              "L/s": "liters_per_second"
             }
           }
         }

--- a/tests/dbo/novirt/site_model_expected/devices/AHU-11/metadata.json
+++ b/tests/dbo/novirt/site_model_expected/devices/AHU-11/metadata.json
@@ -38,8 +38,8 @@
       },
       "economizer_mode": {
         "value_map": {
-          "OFF": "0.0",
-          "ON": "1.0"
+          "0.0": "OFF",
+          "1.0": "ON"
         }
       },
       "exhaust_air_damper_percentage_command": {
@@ -50,14 +50,14 @@
       },
       "failed_exhaust_fan_alarm": {
         "value_map": {
-          "ACTIVE": "1.0",
-          "INACTIVE": "0.0"
+          "1.0": "ACTIVE",
+          "0.0": "INACTIVE"
         }
       },
       "failed_supply_fan_alarm_1": {
         "value_map": {
-          "ACTIVE": "1.0",
-          "INACTIVE": "0.0"
+          "1.0": "ACTIVE",
+          "0.0": "INACTIVE"
         }
       },
       "supply_air_static_pressure_setpoint": {

--- a/tests/dbo/novirt/site_model_expected/devices/BLR-11/metadata.json
+++ b/tests/dbo/novirt/site_model_expected/devices/BLR-11/metadata.json
@@ -26,20 +26,20 @@
     "points": {
       "circulation_pump_run_command": {
         "value_map": {
-          "OFF": "0.0",
-          "ON": "1.0"
+          "0.0": "OFF",
+          "1.0": "ON"
         }
       },
       "circulation_pump_run_status": {
         "value_map": {
-          "OFF": "0.0",
-          "ON": "1.0"
+          "0.0": "OFF",
+          "1.0": "ON"
         }
       },
       "failed_alarm": {
         "value_map": {
-          "ACTIVE": "1.0",
-          "INACTIVE": "0.0"
+          "1.0": "ACTIVE",
+          "0.0": "INACTIVE"
         }
       },
       "heating_percentage_command": {
@@ -47,8 +47,8 @@
       },
       "high_supply_water_temperature_alarm": {
         "value_map": {
-          "ACTIVE": "1.0",
-          "INACTIVE": "0.0"
+          "1.0": "ACTIVE",
+          "0.0": "INACTIVE"
         }
       },
       "return_water_temperature_sensor": {

--- a/tests/dbo/novirt/site_model_expected/devices/CHWP-42/metadata.json
+++ b/tests/dbo/novirt/site_model_expected/devices/CHWP-42/metadata.json
@@ -32,8 +32,8 @@
       },
       "failed_alarm": {
         "value_map": {
-          "ACTIVE": "1.0",
-          "INACTIVE": "0.0"
+          "1.0": "ACTIVE",
+          "0.0": "INACTIVE"
         }
       },
       "power_sensor": {
@@ -41,14 +41,14 @@
       },
       "run_command": {
         "value_map": {
-          "OFF": "0.0",
-          "ON": "1.0"
+          "0.0": "OFF",
+          "1.0": "ON"
         }
       },
       "run_status": {
         "value_map": {
-          "OFF": "0.0",
-          "ON": "1.0"
+          "0.0": "OFF",
+          "1.0": "ON"
         }
       },
       "speed_percentage_command": {

--- a/tests/dbo/novirt/site_model_expected/devices/EM-61/metadata.json
+++ b/tests/dbo/novirt/site_model_expected/devices/EM-61/metadata.json
@@ -27,7 +27,7 @@
         "translation": {
           "units": {
             "values": {
-              "kilovolt_amperes": "kilo-volt-amperes"
+              "kilo-volt-amperes": "kilovolt_amperes"
             }
           }
         }

--- a/tests/dbo/novirt/site_model_expected/devices/FCU-142/metadata.json
+++ b/tests/dbo/novirt/site_model_expected/devices/FCU-142/metadata.json
@@ -38,14 +38,14 @@
       },
       "discharge_fan_run_command": {
         "value_map": {
-          "OFF": "0.0",
-          "ON": "1.0"
+          "0.0": "OFF",
+          "1.0": "ON"
         }
       },
       "discharge_fan_run_status": {
         "value_map": {
-          "OFF": "0.0",
-          "ON": "1.0"
+          "0.0": "OFF",
+          "1.0": "ON"
         }
       },
       "discharge_fan_speed_percentage_command": {
@@ -53,14 +53,14 @@
       },
       "failed_discharge_fan_alarm": {
         "value_map": {
-          "ACTIVE": "1.0",
-          "INACTIVE": "0.0"
+          "1.0": "ACTIVE",
+          "0.0": "INACTIVE"
         }
       },
       "failed_humidifier_alarm": {
         "value_map": {
-          "ACTIVE": "1.0",
-          "INACTIVE": "0.0"
+          "1.0": "ACTIVE",
+          "0.0": "INACTIVE"
         }
       },
       "zone_air_cooling_temperature_setpoint": {

--- a/tests/dbo/novirt/site_model_expected/devices/HX-2/metadata.json
+++ b/tests/dbo/novirt/site_model_expected/devices/HX-2/metadata.json
@@ -35,14 +35,14 @@
       },
       "failed_chilled_return_water_isolation_valve_alarm": {
         "value_map": {
-          "ACTIVE": "1.0",
-          "INACTIVE": "0.0"
+          "1.0": "ACTIVE",
+          "0.0": "INACTIVE"
         }
       },
       "failed_chilled_return_water_temperature_alarm": {
         "value_map": {
-          "ACTIVE": "1.0",
-          "INACTIVE": "0.0"
+          "1.0": "ACTIVE",
+          "0.0": "INACTIVE"
         }
       }
     }

--- a/tests/dbo/novirt/site_model_expected/devices/TF-112/metadata.json
+++ b/tests/dbo/novirt/site_model_expected/devices/TF-112/metadata.json
@@ -26,38 +26,38 @@
     "points": {
       "failed_alarm": {
         "value_map": {
-          "ACTIVE": "1.0",
-          "INACTIVE": "0.0"
+          "1.0": "ACTIVE",
+          "0.0": "INACTIVE"
         }
       },
       "failed_zone_air_temperature_alarm": {
         "value_map": {
-          "ACTIVE": "1.0",
-          "INACTIVE": "0.0"
+          "1.0": "ACTIVE",
+          "0.0": "INACTIVE"
         }
       },
       "run_command": {
         "value_map": {
-          "OFF": "0.0",
-          "ON": "1.0"
+          "0.0": "OFF",
+          "1.0": "ON"
         }
       },
       "run_status": {
         "value_map": {
-          "OFF": "0.0",
-          "ON": "1.0"
+          "0.0": "OFF",
+          "1.0": "ON"
         }
       },
       "schedule_run_command": {
         "value_map": {
-          "OFF": "0.0",
-          "ON": "1.0"
+          "0.0": "OFF",
+          "1.0": "ON"
         }
       },
       "user_occupancy_override_status": {
         "value_map": {
-          "DISABLED": "0.0",
-          "ENABLED": "1.0"
+          "0.0": "DISABLED",
+          "1.0": "ENABLED"
         }
       },
       "zone_air_cooling_temperature_setpoint": {

--- a/tests/dbo/novirt/site_model_expected/devices/VAV-3151/metadata.json
+++ b/tests/dbo/novirt/site_model_expected/devices/VAV-3151/metadata.json
@@ -29,7 +29,7 @@
         "translation": {
           "units": {
             "values": {
-              "no_units": "no-units"
+              "no-units": "no_units"
             }
           }
         }
@@ -39,14 +39,14 @@
       },
       "failed_zone_air_co2_concentration_alarm": {
         "value_map": {
-          "ACTIVE": "1.0",
-          "INACTIVE": "0.0"
+          "1.0": "ACTIVE",
+          "0.0": "INACTIVE"
         }
       },
       "failed_zone_air_temperature_alarm": {
         "value_map": {
-          "ACTIVE": "1.0",
-          "INACTIVE": "0.0"
+          "1.0": "ACTIVE",
+          "0.0": "INACTIVE"
         }
       },
       "heating_request_count": {
@@ -57,8 +57,8 @@
       },
       "schedule_run_command": {
         "value_map": {
-          "OFF": "0.0",
-          "ON": "1.0"
+          "0.0": "OFF",
+          "1.0": "ON"
         }
       },
       "supply_air_flowrate_sensor": {

--- a/tests/dbo/novirt/site_model_expected/devices/WCCH-11/metadata.json
+++ b/tests/dbo/novirt/site_model_expected/devices/WCCH-11/metadata.json
@@ -41,14 +41,14 @@
       },
       "failed_alarm": {
         "value_map": {
-          "ACTIVE": "1.0",
-          "INACTIVE": "0.0"
+          "1.0": "ACTIVE",
+          "0.0": "INACTIVE"
         }
       },
       "run_status": {
         "value_map": {
-          "OFF": "0.0",
-          "ON": "1.0"
+          "0.0": "OFF",
+          "1.0": "ON"
         }
       }
     }

--- a/tests/dbo/virt/site_model_expected/devices/DDC-9/metadata.json
+++ b/tests/dbo/virt/site_model_expected/devices/DDC-9/metadata.json
@@ -24,14 +24,14 @@
     "points": {
       "compressor_run_status_1": {
         "value_map": {
-          "OFF": "0.0",
-          "ON": "1.0"
+          "0.0": "OFF",
+          "1.0": "ON"
         }
       },
       "compressor_run_status_2": {
         "value_map": {
-          "OFF": "0.0",
-          "ON": "1.0"
+          "0.0": "OFF",
+          "1.0": "ON"
         }
       },
       "compressor_speed_percentage_command_1": {


### PR DESCRIPTION
Update DBO semantic conversions inside merge and extract scripts, migrating from "output is the key" to "output is the value" architecture for internal components and UDMI point schemas. Ensures compatibility with standard metadata outputs while preserving external system schemas.

---
*PR created automatically by Jules for task [8671879406895910409](https://jules.google.com/task/8671879406895910409) started by @grafnu*