### PR TITLE
feat: replace translation units with units_as for site configs

### DIFF
--- a/bin/dbo_extract.py
+++ b/bin/dbo_extract.py
@@ -104,26 +104,12 @@ def extract_dbo_config(site_model_dir: Path) -> dict:
       if "present_value" not in pt_dbo:
         pt_dbo["present_value"] = point_info.get("ref", f"points.{point_name}.present_value")
       
-      if "units" not in pt_dbo and "units" in point_info:
-        pt_dbo["units"] = {
-          "key": f"pointset.points.{point_name}.units",
-          "values": {point_info["units"]: point_info["units"]}
-        }
-      elif "units" in pt_dbo:
-        u = pt_dbo["units"].copy()
-        # Derive key from point name if it was stripped
-        u["key"] = f"pointset.points.{point_name}.units"
-        if "values" not in u and "units" in point_info:
-          u["values"] = {point_info["units"]: point_info["units"]}
-        elif "values" in u and "units" in point_info:
-          # If there are already mappings, we might need to add the identity one back 
-          # if it was stripped (though usually it's one-to-one).
-          # For now, ensure the UDMI unit is represented.
-          udmi_unit = point_info["units"]
-          if udmi_unit not in u["values"].values():
-            u["values"][udmi_unit] = udmi_unit
-        if "values" in u:
-          u["values"] = {v: k for k, v in u["values"].items()}
+      if "units" in point_info:
+        u = {"key": f"pointset.points.{point_name}.units"}
+        u_vals = {point_info["units"]: point_info["units"]}
+        if "units_as" in point_info:
+          u_vals[point_info["units"]] = point_info["units_as"]
+        u["values"] = u_vals
         pt_dbo["units"] = u
 
       if "states" not in pt_dbo and "value_map" in point_info:

--- a/bin/dbo_merge.py
+++ b/bin/dbo_merge.py
@@ -156,8 +156,16 @@ def merge_dbo_config(yaml_file: Path, site_model_dir: Path):
             if pv != "present_value" and pv != f"points.{pt_name}.present_value":
               pt_udmi["ref"] = pv
           if "units" in pt_dbo and "values" in pt_dbo["units"]:
-            udmi_unit = list(pt_dbo["units"]["values"].keys())[0]
-            pt_udmi["units"] = udmi_unit
+            values = pt_dbo["units"]["values"]
+            if len(values) > 1:
+              raise ValueError(f"Too many unit translations for point {pt_name}: {values}")
+            for udmi_unit, device_unit in values.items():
+              if "units" not in pt_udmi:
+                pt_udmi["units"] = udmi_unit
+              elif pt_udmi["units"] != udmi_unit:
+                raise ValueError(f"Unit mismatch: mapped target unit {udmi_unit} does not match explicit units {pt_udmi['units']}")
+              if device_unit != udmi_unit:
+                pt_udmi["units_as"] = device_unit
           if "states" in pt_dbo:
             pt_udmi["value_map"] = {v: k for k, v in pt_dbo["states"].items()}
           
@@ -167,18 +175,7 @@ def merge_dbo_config(yaml_file: Path, site_model_dir: Path):
             del clean_pt_dbo["present_value"]
           
           if "units" in clean_pt_dbo:
-            u = clean_pt_dbo["units"].copy()
-            if u.get("key") == f"pointset.points.{pt_name}.units":
-              del u["key"]
-            if "values" in u:
-              # Only keep non-identity mappings
-              u["values"] = {v: k for k, v in u["values"].items() if k != v}
-              if not u["values"]:
-                del u["values"]
-            if not u:
-              del clean_pt_dbo["units"]
-            else:
-              clean_pt_dbo["units"] = u
+            del clean_pt_dbo["units"]
 
           # States are already in value_map, so they are redundant here
           if "states" in clean_pt_dbo:

--- a/schema/building_translation.json
+++ b/schema/building_translation.json
@@ -10,19 +10,11 @@
       "description": "dotted path to present_value field",
       "type": "string"
     },
-    "units": {
-      "type": "object",
-      "properties": {
-        "key": { "type": "string" },
-        "values": {
-          "type": "object",
-          "additionalProperties": { "type": "string" }
-        }
-      }
-    },
     "states": {
       "type": "object",
-      "additionalProperties": { "type": "string" }
+      "additionalProperties": {
+        "type": "string"
+      }
     }
   }
 }

--- a/schema/model_pointset_point.json
+++ b/schema/model_pointset_point.json
@@ -10,9 +10,16 @@
       "description": "Expected unit configuration for the point",
       "type": "string"
     },
+    "units_as": {
+      "type": "string"
+    },
     "type": {
       "description": "Expected data type for the point",
-      "enum": ["string", "boolean", "number"]
+      "enum": [
+        "string",
+        "boolean",
+        "number"
+      ]
     },
     "description": {
       "description": "Detailed description of this point",
@@ -24,12 +31,16 @@
     },
     "baseline_value": {
       "description": "Represents the expected baseline value of the point",
-      "examples": [22]
+      "examples": [
+        22
+      ]
     },
     "baseline_tolerance": {
       "type": "number",
       "description": "Maximum deviation from `baseline_value`",
-      "examples": [2]
+      "examples": [
+        2
+      ]
     },
     "baseline_state": {
       "description": "Expected state when `baseline_value` is set as the `set_value` for this point the config message",
@@ -44,27 +55,38 @@
     "range_min": {
       "description": "Represents the lower bound of the error threshold for a point",
       "type": "number",
-      "examples": [0]
+      "examples": [
+        0
+      ]
     },
     "range_max": {
       "description": "Represents the upper bound of the error threshold for a point",
       "type": "number",
-      "examples": [100]
+      "examples": [
+        100
+      ]
     },
     "unchanged_limit_sec": {
       "description": "Represents the limit in seconds that a point can be unchanged for",
       "type": "integer",
-      "examples": [3600]
+      "examples": [
+        3600
+      ]
     },
     "cov_increment": {
       "description": "Triggering threshold for partial cov update publishing",
-      "examples": [1],
+      "examples": [
+        1
+      ],
       "type": "number"
     },
     "ref": {
       "description": "Mapping for the point to an internal resource (e.g. BACnet object reference)",
       "type": "string",
-      "examples": ["AI3", "400070"]
+      "examples": [
+        "AI3",
+        "400070"
+      ]
     },
     "adjunct": {
       "type": "object",
@@ -76,14 +98,22 @@
         }
       }
     },
-    "tags":{
+    "tags": {
       "description": "Tags assosciated with the point",
       "type": "array",
       "uniqueItems": true,
       "items": {
         "pattern": "^[a-z0-9]+$"
       },
-      "examples": [["lighting"], ["energy", "hvac"]]
+      "examples": [
+        [
+          "lighting"
+        ],
+        [
+          "energy",
+          "hvac"
+        ]
+      ]
     },
     "structure": {
       "description": "Collection of family point information",
@@ -99,7 +129,9 @@
       "type": "string",
       "description": "Virtual equipment mapping linking this local point to a remote point in another device",
       "pattern": "^[-0-9a-zA-Z$]+:[a-z0-9_]+$",
-      "examples": ["VAV-3:supply_air_flowrate_sensor"]
+      "examples": [
+        "VAV-3:supply_air_flowrate_sensor"
+      ]
     },
     "translation": {
       "$ref": "file:building_translation.json#"

--- a/tests/dbo/basic/site_model_expected/devices/VAV-1/metadata.json
+++ b/tests/dbo/basic/site_model_expected/devices/VAV-1/metadata.json
@@ -16,13 +16,7 @@
     "points": {
       "zone_air_temperature_sensor": {
         "units": "degrees_celsius",
-        "translation": {
-          "units": {
-            "values": {
-              "degC": "degrees_celsius"
-            }
-          }
-        }
+        "units_as": "degC"
       },
       "supply_air_flowrate_sensor_1": {
         "expr": "VAV-3:supply_air_flowrate_sensor"

--- a/tests/dbo/basic/site_model_expected/devices/VAV-2/metadata.json
+++ b/tests/dbo/basic/site_model_expected/devices/VAV-2/metadata.json
@@ -23,13 +23,7 @@
     "points": {
       "zone_air_temperature_sensor": {
         "units": "degrees_celsius",
-        "translation": {
-          "units": {
-            "values": {
-              "degC": "degrees_celsius"
-            }
-          }
-        }
+        "units_as": "degC"
       }
     }
   }

--- a/tests/dbo/basic/site_model_expected/devices/VAV-3/metadata.json
+++ b/tests/dbo/basic/site_model_expected/devices/VAV-3/metadata.json
@@ -16,13 +16,7 @@
     "points": {
       "supply_air_flowrate_sensor": {
         "units": "liters_per_second",
-        "translation": {
-          "units": {
-            "values": {
-              "L/s": "liters_per_second"
-            }
-          }
-        }
+        "units_as": "L/s"
       }
     }
   }

--- a/tests/dbo/novirt/site_model_expected/devices/EM-61/metadata.json
+++ b/tests/dbo/novirt/site_model_expected/devices/EM-61/metadata.json
@@ -24,13 +24,7 @@
     "points": {
       "apparent_power_sensor": {
         "units": "kilovolt_amperes",
-        "translation": {
-          "units": {
-            "values": {
-              "kilo-volt-amperes": "kilovolt_amperes"
-            }
-          }
-        }
+        "units_as": "kilo-volt-amperes"
       },
       "average_inter_line_voltage_sensor": {
         "units": "volts"

--- a/tests/dbo/novirt/site_model_expected/devices/VAV-3151/metadata.json
+++ b/tests/dbo/novirt/site_model_expected/devices/VAV-3151/metadata.json
@@ -26,13 +26,7 @@
     "points": {
       "cooling_request_count": {
         "units": "no_units",
-        "translation": {
-          "units": {
-            "values": {
-              "no-units": "no_units"
-            }
-          }
-        }
+        "units_as": "no-units"
       },
       "discharge_air_temperature_sensor": {
         "units": "degrees-fahrenheit"


### PR DESCRIPTION
Refactored unit translations by replacing the nested `translation.units.values` object with an optional top-level `units_as` string property. Enforced strict validation during DBO merging to ensure that only a single unit translation exists per point and that the mapped target unit correctly aligns with the point's explicit units. 

Updated both schema definitions (`building_translation.json`, `model_pointset_point.json`) and the DBO converters (`bin/dbo_merge.py`, `bin/dbo_extract.py`), along with corresponding testing artifacts in `tests/dbo`.

---
*PR created automatically by Jules for task [14826262197338357107](https://jules.google.com/task/14826262197338357107) started by @grafnu*