### PR TITLE
fix: Resolve null thread reference in EtherDiscovery teardown

### DIFF
--- a/misc/discoverynode/src/udmi/discovery/ether.py
+++ b/misc/discoverynode/src/udmi/discovery/ether.py
@@ -140,7 +140,8 @@ class EtherDiscovery(discovery.DiscoveryController):
   def nmap_stop_discovery(self):
     logging.info("stopping")
     self.cancel_threads.set()
-    self.nmap_thread.join()
+    if self.nmap_thread and self.nmap_thread.is_alive():
+      self.nmap_thread.join()
 
   @discovery.catch_exceptions_to_state
   @discovery.main_task


### PR DESCRIPTION
Resolves a test crash occurring during teardown of `udmi.discovery.ether`. 

**🎯 What**
Added a check to `nmap_stop_discovery` that verifies the `nmap_thread` is not `None` and is currently active before calling `.join()`.

**⚠️ Risk**
Very low. This follows standard thread safety patterns in Python and handles teardowns smoothly when execution doesn't perfectly align with thread startup.

**🛡️ Solution**
Replaced blind invocation of `self.nmap_thread.join()` with `if self.nmap_thread and self.nmap_thread.is_alive(): self.nmap_thread.join()`.

---
*PR created automatically by Jules for task [4013373380718883524](https://jules.google.com/task/4013373380718883524) started by @grafnu*