### PR TITLE
🔒 [security fix] Fix nmap XML parsing to use defusedxml

### DIFF
--- a/misc/discoverynode/src/requirements.txt
+++ b/misc/discoverynode/src/requirements.txt
@@ -15,3 +15,4 @@ python-dotenv==1.2.2
 pytz==2025.2
 scapy==2.7.0
 pyasyncore==1.0.5
+defusedxml==0.7.1

--- a/misc/discoverynode/src/udmi/discovery/utils/nmap.py
+++ b/misc/discoverynode/src/udmi/discovery/utils/nmap.py
@@ -2,7 +2,7 @@
 
 import dataclasses
 from typing import Generator
-import xml.etree.ElementTree
+import defusedxml.ElementTree
 
 @dataclasses.dataclass(unsafe_hash=True, order=True)
 class NmapPort:
@@ -43,7 +43,7 @@ def results_reader(nmap_file: str) -> Generator[NmapHost, None, None]:
     NmapHost resu
   """
   hosts = []
-  root = xml.etree.ElementTree.parse(nmap_file).getroot()
+  root = defusedxml.ElementTree.parse(nmap_file).getroot()
   for _host in root.iter('host'):
     host = NmapHost()
 


### PR DESCRIPTION
🎯 What
Migrated from `xml.etree.ElementTree` to `defusedxml.ElementTree` in `misc/discoverynode/src/udmi/discovery/utils/nmap.py` and pinned `defusedxml==0.7.1` in `misc/discoverynode/src/requirements.txt` to fix Discovery Tests.

⚠️ Risk
Low risk. `defusedxml` acts as a drop-in safe substitute for the standard `xml.etree.ElementTree` package, specifically designed to mitigate XXE and entity expansion vulnerabilities when parsing untrusted XML data (like nmap output). 

🛡️ Solution
Replaced `xml.etree.ElementTree` with `defusedxml.ElementTree` in the nmap parser. Included `defusedxml` in `requirements.txt`. Tested natively using virtualenv to verify imports and test execution behavior.

---
*PR created automatically by Jules for task [14867297504262404728](https://jules.google.com/task/14867297504262404728) started by @grafnu*